### PR TITLE
add MessagePartCount

### DIFF
--- a/recipient.go
+++ b/recipient.go
@@ -4,9 +4,10 @@ import "time"
 
 // Recipient struct holds information for a single msisdn with status details.
 type Recipient struct {
-	Recipient      int64
-	Status         string
-	StatusDatetime *time.Time
+	Recipient        int64
+	Status           string
+	StatusDatetime   *time.Time
+	MessagePartCount int
 }
 
 // Recipients holds a collection of Recepient structs along with send stats.


### PR DESCRIPTION
Long SMS messages get split up into multiple message segments by messagebird. For example, a message with body "Hello world!" might get split into 2 segments "Hello w" and "orld!" 

So adding the MessagePartCount field in recipient.go so that we are able to populate NumSegments from the response. 